### PR TITLE
Disable root/alpine passwords instead scrambling them

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ built-in. The only required dependencies are:
 
 - bash-like shell (e.g. bash, dash, ash)
 - wget
+- resize2fs
 
 ## Supported Features and Environments
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ those things. Instead it supports:
 - setting system hostname
 - install user's configured SSH keys to the alpine user's authorized_keys file
 - run any script-like user data (must start with #!)
-- scramble root and alpine password
+- disable root and alpine password
 - resize root partition to available disk space
 
 These steps only run once. After the initial bootstrap the bootstrapper script

--- a/tiny-ec2-bootstrap
+++ b/tiny-ec2-bootstrap
@@ -56,8 +56,8 @@ _resize_root_partition() {
     resize2fs $(mountpoint -n / | cut -d' ' -f1)
 }
 
-_scramble_password() {
-    echo "$1:$(head -c 100 /dev/urandom | sha512sum | cut -d' ' -f1)" | chpasswd
+_disable_password() {
+    echo "$1:*" | chpasswd -e
 }
 
 start() {
@@ -66,8 +66,8 @@ start() {
 
     [ -d "/var/lib/cloud" ] || mkdir -p /var/lib/cloud
 
-    ebegin "Scrambling root password"; _scramble_password root; eend $?
-    ebegin "Scrambling alpine password"; _scramble_password alpine; eend $?
+    ebegin "Disabling root password"; _disable_password root; eend $?
+    ebegin "Disabling alpine password"; _disable_password alpine; eend $?
     ebegin "Resizing root partition"; _resize_root_partition; eend $?
     ebegin "Setting ec2 hostname"; _update_hostname; eend $?
     ebegin "Setting ec2 user ssh keys"; _set_ssh_keys "alpine"; eend $?


### PR DESCRIPTION
Also, explicitly state `resize2fs` as a dependency in the README.