### PR TITLE
Use correct ft in vim modeline

### DIFF
--- a/tiny-ec2-bootstrap
+++ b/tiny-ec2-bootstrap
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# vim:set ft=bash:
+# vim:set ft=sh:
 
 description="Provides EC2 cloud bootstrap"
 

--- a/tiny-ec2-bootstrap
+++ b/tiny-ec2-bootstrap
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# vim:set ft=sh:
+# vim:set ft=sh et ts=4 sts=4 sw=4:
 
 description="Provides EC2 cloud bootstrap"
 


### PR DESCRIPTION
Alpine machines does not have to have bash install (and even if they did, I'm
not really sure openrc would use it). So ft should be just sh.