### PR TITLE
Expand root to all available volume space when it's a partition

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Michael Crute
+Copyright (c) 2017-2020 Michael Crute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ and cloud platform support for small size and limited external dependencies.
 ## Requirements
 
 The most important feature of this bootstrapper is the very limited set of
-dependencies. In-fact, this works with just busybox -- provided the wget applet
-is built-in -- and resize2fs. The only required dependencies are:
+dependencies. In-fact, this works with just BusyBox (provided ash and wget
+are built in) and a couple utilities for expanding the root filesystem.
+The full list of required dependencies are:
 
 - bash-like shell (e.g. bash, dash, ash)
 - wget
+- sfdisk
+- partx
 - resize2fs
 
 ## Supported Features and Environments
@@ -33,7 +36,7 @@ those things. Instead it supports:
 - installing the instance's SSH keys in the EC2 user's authorized_keys file
 - running any script-like user data (must start with #!)
 - disabling root and the EC2 user's password
-- resizing root partition to available disk space
+- expanding root partition to available disk space
 
 These steps only run once. After the initial bootstrap the bootstrapper script
 is a no-op. To force the script to run again at boot time remove the file

--- a/tiny-ec2-bootstrap
+++ b/tiny-ec2-bootstrap
@@ -66,11 +66,22 @@ _run_userdata() {
 		ec=$(cat "$ec_file")
 
 		echo "User Data Script Exit Status: $ec"
-		return $ec
+		return "$ec"
 	fi
 }
 
 _resize_root_partition() {
+	local mountpoint="$(mountpoint -n / | cut -d' ' -f1)"
+
+	# mountpoint is the second partition...
+	if echo "$mountpoint" | cut -d' ' -f1 | grep -qE '/(nvme\d+n\d+p|xvd[a-z]+)2$'; then
+		local volume="$(echo "$mountpoint" | sed -Ee 's/(nvme\d+n\d+|xvd[a-z]+)p?2/\1/')"
+		einfo "Expanding root partition to volume size..."
+		echo ", +" | sfdisk -q --no-reread -N 2 "$volume"
+		einfo "Updating kernel with new partition table..."
+		partx -u "$volume"
+	fi
+	einfo "Resizing..."
 	resize2fs "$(mountpoint -n / | cut -d' ' -f1)"
 }
 
@@ -86,7 +97,7 @@ start() {
 
 	ebegin "Disabling root password"; _disable_password root; eend $?
 	ebegin "Disabling $EC2_USER password"; _disable_password "$EC2_USER"; eend $?
-	ebegin "Resizing root partition"; _resize_root_partition; eend $?
+	ebegin "Expanding root partition"; _resize_root_partition; eend $?
 	ebegin "Setting ec2 hostname"; _update_hostname; eend $?
 	ebegin "Setting ec2 user ssh keys"; _set_ssh_keys "$EC2_USER"; eend $?
 	ebegin "Running ec2 user data script"; _run_userdata; eend $?


### PR DESCRIPTION
Fixes #15 

Manually doing what the script does...
```
alpine@ip-172-31-55-52:~$ df -h
Filesystem                Size      Used Available Use% Mounted on
/dev/nvme0n1p2          985.0M    111.2M    806.9M  12% /
```
```
root@ip-172-31-55-52:~# echo ", +" | sfdisk --no-reread -N 2 /dev/nvme0n1
GPT PMBR size mismatch (2097151 != 20971519) will be corrected by write.
The backup GPT table is not on the end of the device. This problem will be corrected by write.
Disk /dev/nvme0n1: 10 GiB, 10737418240 bytes, 20971520 sectors
Disk model: Amazon Elastic Block Store
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 00E78CAF-AFC7-49A8-A758-31719F801C98

Old situation:

Device         Start     End Sectors  Size Type
/dev/nvme0n1p1  4096   14335   10240    5M EFI System
/dev/nvme0n1p2 14336 2097118 2082783 1017M Linux filesystem

/dev/nvme0n1p2:
New situation:
Disklabel type: gpt
Disk identifier: 00E78CAF-AFC7-49A8-A758-31719F801C98

Device         Start      End  Sectors Size Type
/dev/nvme0n1p1  4096    14335    10240   5M EFI System
/dev/nvme0n1p2 14336 20971486 20957151  10G Linux filesystem

The partition table has been altered.
Calling ioctl() to re-read partition table.
Re-reading the partition table failed.: Resource busy
The kernel still uses the old table. The new table will be used at the next reboot or after you run partprobe(8) or partx(8).
Syncing disks.
```
```
root@ip-172-31-55-52:~# partx -u /dev/nvme0n1
```
```
root@ip-172-31-55-52:~# resize2fs /dev/nvme0n1p2
resize2fs 1.45.6 (20-Mar-2020)
Filesystem at /dev/nvme0n1p2 is mounted on /; on-line resizing required
old_desc_blocks = 1, new_desc_blocks = 1
The filesystem on /dev/nvme0n1p2 is now 2619643 (4k) blocks long.
```
```
root@ip-172-31-55-52:~# df -h /
Filesystem                Size      Used Available Use% Mounted on
/dev/nvme0n1p2            9.8G    115.4M      9.3G   1% /
```