### PR TITLE
Also lock account when changing password

### DIFF
--- a/tiny-ec2-bootstrap
+++ b/tiny-ec2-bootstrap
@@ -86,7 +86,7 @@ _resize_root_partition() {
 }
 
 _disable_password() {
-	echo "$1:*" | chpasswd -e
+	passwd -l "$1"
 }
 
 start() {


### PR DESCRIPTION
The Amazon marketplace image verifier expects the root account to be
locked, not just cleared. Otherwise images that use the bootstrap can't
be pushed to the AWS marketplace.